### PR TITLE
Modify default zoom to fit screen

### DIFF
--- a/libretro/libretro-cap32.h
+++ b/libretro/libretro-cap32.h
@@ -11,8 +11,8 @@
 
 #define TEX_WIDTH 400
 #define TEX_HEIGHT 300
-#define CROP_WIDTH 400
-#define CROP_HEIGHT 260
+#define CROP_WIDTH 320
+#define CROP_HEIGHT 220
 
 #define NPLGN 10
 #define NLIGN 5
@@ -22,8 +22,8 @@
 #define YSIDE  (CROP_HEIGHT/8 -1)
 
 #define YBASE0 (CROP_HEIGHT - NLIGN*YSIDE -8)
-#define XBASE0 0+4+2
-#define XBASE3 0
+#define XBASE0 36+4+2
+#define XBASE3 36
 #define YBASE3 YBASE0 -4
 
 #define STAT_DECX 120

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -23,9 +23,9 @@ extern int sndbufsize;
 signed short rsnd=0;
 
 unsigned short zoom[MXZO*MYZO*2];
-int ZOOM=-1;
+int ZOOM=3;
 
-MRES Mres[5]={ {256,192},{256,232},{272,232},{320,232}, {320,256}};
+MRES Mres[5]={ {256,192},{256,232},{272,232},{320,200}, {320,256}};
 
 static retro_video_refresh_t video_cb;
 static retro_audio_sample_t audio_cb;
@@ -118,7 +118,7 @@ void display_zoom(void)
 	int i;
 	int XZO=Mres[ZOOM].x,YZO=Mres[ZOOM].y;
 
-	unsigned short *ptr=&bmp[ (384-XZO)/2 +400*(272-YZO)/2];
+	unsigned short *ptr=&bmp[ (384-XZO)/2 +400*(282-YZO)/2];
 	unsigned short *out=&zoom[0];
 
 	for(i = 0;i < YZO; i++)


### PR DESCRIPTION
Set default emulated resolution to 320x200 which fits most games.
Modified on screen keyboard to match this resolution.
