### PR TITLE
[fix] remove malloc.h include

### DIFF
--- a/cap32/libcpccat/fs.c
+++ b/cap32/libcpccat/fs.c
@@ -10,7 +10,6 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
malloc.h is a non-standard header
malloc is declared in stdlib.h