### PR TITLE
Bug : m3u with specified command

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -27,5 +27,7 @@ SOURCES_C += $(CORE_DIR)/cap32/tape.c
 SOURCES_C += $(CORE_DIR)/cap32/z80.c
 SOURCES_C += $(CORE_DIR)/cap32/libcpccat/fs.c
 SOURCES_C += $(CORE_DIR)/cap32/kbdauto.c
-SOURCES_C += $(CORE_DIR)/libretro/disk_control.c
+SOURCES_C += $(CORE_DIR)/libretro/retro_strings.c
+SOURCES_C += $(CORE_DIR)/libretro/retro_files.c
+SOURCES_C += $(CORE_DIR)/libretro/retro_disk_control.c
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -934,7 +934,6 @@ void retro_run(void)
 						char* command = calloc(strlen(dc->command) + 1, sizeof(char));
 						sprintf(command, "%s\n", dc->command);
 						kbd_buf_feed(command);
-						kbd_buf_update();
 						free(command);
 					}						
 					else
@@ -972,7 +971,6 @@ void retro_run(void)
 			{
 				tape_insert ((char *)RPATH);
 				kbd_buf_feed("|tape\nrun\"\n^");
-				kbd_buf_update();
 				return;
 
 			}

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -16,71 +16,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "disk_control.h"
+#include "retro_disk_control.h"
+#include "retro_strings.h"
+#include "retro_files.h"
 
-#include <sys/types.h> 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+/*#include <sys/types.h> 
 #include <sys/stat.h> 
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <unistd.h>*/
 
 #define COMMENT "#"
 #define M3U_SPECIAL_COMMAND "#COMMAND:"
 
-#ifdef _WIN32
-#define PATH_JOIN_SEPARATOR   		"\\"
-// Windows also support the unix path separator
-#define PATH_JOIN_SEPARATOR_ALT   	"/"
-#else
-#define PATH_JOIN_SEPARATOR   		"/"
-#endif
-
-// Note: This function returns a pointer to a substring_left of the original string.
-// If the given string was allocated dynamically, the caller must not overwrite
-// that pointer with the returned value, since the original pointer must be
-// deallocated using the same allocator with which it was allocated.  The return
-// value must NOT be deallocated using free() etc.
-char *trimwhitespace(char *str)
-{
-  char *end;
-
-  // Trim leading space
-  while(isspace((unsigned char)*str)) str++;
-
-  if(*str == 0)  // All spaces?
-    return str;
-
-  // Trim trailing space
-  end = str + strlen(str) - 1;
-  while(end > str && isspace((unsigned char)*end)) end--;
-
-  // Write new null terminator character
-  end[1] = '\0';
-
-  return str;
-}
-
-// Returns a substring of 'str' that contains the 'len' leftmost characters of 'str'.
-char* strleft(char* str, int len)
-{
-	char* result = calloc(len + 1, sizeof(char));
-	strncpy(result, str, len);
-	return result;
-}
-
-// Returns a substring of 'str' that contains the 'len' rightmost characters of 'str'.
-char* strright(char* str, int len)
-{
-	int pos = strlen(str) - len;
-	char* result = calloc(len + 1, sizeof(char));
-	strncpy(result, str + pos, len);
-	return result;
-}
-
 // Return the directory name of filename 'filename'.
-char* dirname_int(char* filename)
+char* dirname_int(const char* filename)
 {
 	if (filename == NULL)
 		return NULL;
@@ -88,12 +42,12 @@ char* dirname_int(char* filename)
 	char* right;
 	int len = strlen(filename);
 	
-	if ((right = strrchr(filename, PATH_JOIN_SEPARATOR[0])) != NULL)
+	if ((right = strrchr(filename, RETRO_PATH_SEPARATOR[0])) != NULL)
 		return strleft(filename, len - strlen(right));
 	
 #ifdef _WIN32
 	// Alternative search for windows beceause it also support the UNIX seperator
-	if ((right = strrchr(filename, PATH_JOIN_SEPARATOR_ALT[0])) != NULL)
+	if ((right = strrchr(filename, RETRO_PATH_SEPARATOR_ALT[0])) != NULL)
 		return strleft(filename, len - strlen(right));
 #endif
 	
@@ -101,39 +55,26 @@ char* dirname_int(char* filename)
 	return NULL;
 }
 
-// Verify if file exists
-int file_exist(char *filename)
-{
-  struct stat buffer;   
-  return (stat(filename, &buffer) == 0);
-}
-
-char* path_join(char* basedir, char* filename)
-{
-	int len = strlen(basedir) + strlen(PATH_JOIN_SEPARATOR) + strlen(filename);
-	char* result = calloc(len + 1, sizeof(char));
-	sprintf(result, "%s%s%s", basedir, PATH_JOIN_SEPARATOR, filename);
-	return result;
-}	
-
-char* m3u_search_file(char* basedir, char* dskName)
+char* m3u_search_file(const char* basedir, const char* dskName)
 {
 	// Verify if this item is an absolute pathname (or the file is in working dir)
-	if (file_exist(dskName))
+	if (file_exists(dskName))
 	{
 		// Copy and return
-		int len = strlen(dskName);
-		char* result = calloc(len + 1, sizeof(char));
-		strncpy(result, dskName, len);
+		char* result = calloc(strlen(dskName) + 1, sizeof(char));
+		strcpy(result, dskName);
 		return result;
 	}
 	
 	// If basedir was provided
 	if(basedir != NULL)
 	{
+		// Join basedir and dskName
+		char* dskPath = calloc(RETRO_PATH_MAX, sizeof(char));
+		path_join(dskPath, basedir, dskName);
+
 		// Verify if this item is a relative filename (append it to the m3u path)
-		char* dskPath = path_join(basedir, dskName);
-		if (file_exist(dskPath))
+		if (file_exists(dskPath))
 		{
 			// Return
 			return dskPath;
@@ -210,7 +151,7 @@ bool dc_add_file_int(dc_storage* dc, char* filename)
 	return false;
 }
 
-bool dc_add_file(dc_storage* dc, char* filename)
+bool dc_add_file(dc_storage* dc, const char* filename)
 {
 	// Verify
 	if(dc == NULL)
@@ -220,13 +161,12 @@ bool dc_add_file(dc_storage* dc, char* filename)
 		return false;
 
 	// Copy and return
-	int len = strlen(filename);
-	char* filename_int = calloc(len + 1, sizeof(char));
-	strncpy(filename_int, filename, len);
+	char* filename_int = calloc(strlen(filename) + 1, sizeof(char));
+	strcpy(filename_int, filename);
 	return dc_add_file_int(dc, filename_int);
 }
 
-void dc_parse_m3u(dc_storage* dc, char* m3u_file)
+void dc_parse_m3u(dc_storage* dc, const char* m3u_file)
 {
 	// Verify
 	if(dc == NULL)
@@ -254,11 +194,11 @@ void dc_parse_m3u(dc_storage* dc, char* m3u_file)
 		char* string = trimwhitespace(buffer);
 		
 		// If it's a m3u special key or a file
-		if ((strlen(buffer) >= strlen(M3U_SPECIAL_COMMAND)) && !strncmp((char*)&buffer, M3U_SPECIAL_COMMAND, strlen(M3U_SPECIAL_COMMAND)))
+		if (strstartswith(string, M3U_SPECIAL_COMMAND))
 		{
 			dc->command = strright(string, strlen(string) - strlen(M3U_SPECIAL_COMMAND));
 		}
-		else if ((strlen(string) >= strlen(COMMENT)) && strncmp(string, COMMENT, strlen(COMMENT)))
+		else if (!strstartswith(string, COMMENT))
 		{
 			// Search the file (absolute, relative to m3u)
 			char* filename;

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -16,11 +16,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef DISK_CONTROL_H__
-#define DISK_CONTROL_H__
+#ifndef RETRO_DISK_CONTROL_H__
+#define RETRO_DISK_CONTROL_H__
 
 #include <stdbool.h>
 
+//*****************************************************************************
+// Disk control structure and functions
 #define DC_MAX_SIZE 20
 
 struct dc_storage{
@@ -32,10 +34,9 @@ struct dc_storage{
 };
 
 typedef struct dc_storage dc_storage;
-
 dc_storage* dc_create(void);
-void dc_parse_m3u(dc_storage* dc, char* m3u_file);
-bool dc_add_file(dc_storage* dc, char* filename);
+void dc_parse_m3u(dc_storage* dc, const char* m3u_file);
+bool dc_add_file(dc_storage* dc, const char* filename);
 void dc_free(dc_storage* dc);
 
 #endif

--- a/libretro/retro_files.c
+++ b/libretro/retro_files.c
@@ -1,0 +1,41 @@
+/* Copyright (C) 2018 
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "retro_files.h"
+
+#include <sys/stat.h> 
+#include <stdio.h>
+#include <string.h>
+
+// Verify if file exists
+bool file_exists(const char *filename)
+{
+	struct stat buf;
+	if (stat(filename, &buf) == 0 &&
+	    (buf.st_mode & (S_IRUSR|S_IWUSR)) && !(buf.st_mode & S_IFDIR))
+	{
+		/* file points to user readable regular file */
+		return true;
+	}
+	return false;
+}
+
+void path_join(char* out, const char* basedir, const char* filename)
+{
+	snprintf(out, RETRO_PATH_MAX, "%s%s%s", basedir, RETRO_PATH_SEPARATOR, filename);
+}	

--- a/libretro/retro_files.h
+++ b/libretro/retro_files.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2018 
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef RETRO_FILES_H__
+#define RETRO_FILES_H__
+
+#include <stdbool.h>
+
+//*****************************************************************************
+// File helpers functions
+#define RETRO_PATH_MAX 512
+
+#ifdef _WIN32
+#define RETRO_PATH_SEPARATOR   		"\\"
+// Windows also support the unix path separator
+#define RETRO_PATH_SEPARATOR_ALT   	"/"
+#else
+#define RETRO_PATH_SEPARATOR   		"/"
+#endif
+
+void path_join(char* out, const char* basedir, const char* filename);
+bool file_exists(const char *filename);
+
+#endif

--- a/libretro/retro_strings.c
+++ b/libretro/retro_strings.c
@@ -1,0 +1,86 @@
+/* Copyright (C) 2018 
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "retro_strings.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Note: This function returns a pointer to a substring_left of the original string.
+// If the given string was allocated dynamically, the caller must not overwrite
+// that pointer with the returned value, since the original pointer must be
+// deallocated using the same allocator with which it was allocated.  The return
+// value must NOT be deallocated using free() etc.
+char* trimwhitespace(char *str)
+{
+  char *end;
+
+  // Trim leading space
+  while(isspace((unsigned char)*str)) str++;
+
+  if(*str == 0)  // All spaces?
+    return str;
+
+  // Trim trailing space
+  end = str + strlen(str) - 1;
+  while(end > str && isspace((unsigned char)*end)) end--;
+
+  // Write new null terminator character
+  end[1] = '\0';
+
+  return str;
+}
+
+// Returns a substring of 'str' that contains the 'len' leftmost characters of 'str'.
+char* strleft(const char* str, int len)
+{
+	char* result = calloc(len + 1, sizeof(char));
+	strncpy(result, str, len);
+	return result;
+}
+
+// Returns a substring of 'str' that contains the 'len' rightmost characters of 'str'.
+char* strright(const char* str, int len)
+{
+	int pos = strlen(str) - len;
+	char* result = calloc(len + 1, sizeof(char));
+	strncpy(result, str + pos, len);
+	return result;
+}
+
+// Returns true if 'str' starts with 'start'
+bool strstartswith(const char* str, const char* start)
+{
+	if (strlen(str) >= strlen(start))
+		if(!strncasecmp(str, start, strlen(start)))
+			return true;
+		
+	return false;
+}
+
+// Returns true if 'str' ends with 'end'
+bool strendswith(const char* str, const char* end)
+{
+	if (strlen(str) >= strlen(end))
+		if(!strcasecmp((char*)&str[strlen(str)-strlen(end)], end))
+			return true;
+		
+	return false;
+}

--- a/libretro/retro_strings.h
+++ b/libretro/retro_strings.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2018 
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef RETRO_STRINGS_H__
+#define RETRO_STRINGS_H__
+
+#include <stdbool.h>
+
+//*****************************************************************************
+// String helpers functions
+char* trimwhitespace(char *str);
+char* strleft(const char* str, int len);
+char* strright(const char* str, int len);
+bool strstartswith(const char* str, const char* start);
+bool strendswith(const char* str, const char* end);
+
+#endif

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ F12 PLAY TAPE
 
 ## M3U and Disk control
 
-This core now support the usage of M3U file and disk control from within RetroArch for multi disk games.
+When you have a multi disk game, you can use a m3u file to specify each disk of the game and change them from the RetroArch Disk control interface.
 
 A M3U file is a simple text file with one disk per line (see https://en.wikipedia.org/wiki/M3U).
 
@@ -68,13 +68,16 @@ Alive (F) - Disk 1B.dsk
 ```
 Path can be absolute or relative to the location of the M3U file.
 
-In RetroArch you can change the current disk in the 'Disk Control' menu. Just select the right disk index when a game ask for it.
+When a game ask for it, you can change the current disk in the RetroArch 'Disk Control' menu :
+- Eject the current disk with 'Disk Cycle Tray Status'.
+- Select the right disk index.
+- Insert the new disk with 'Disk Cycle Tray Status'.
 
-No need to eject disk ('Disk Cycle Tray Status'), you just have to cycle through disk indexes.
+When the core start, the first disk will be mounted and the first executable autostarted (if autostart is enabled).
 
-On start, the first disk will be mounted and the first executable autostarted.
+### Specify a specific command to launch a game
 
-### Special feature for frontend users
+If the autolaunch option of the core does a pretty good job to guess what command must be executed to launch a game on the CPC, there is some problems (cpm disk and strange catalogs for the most).
 
 You can specify a command to be executed on the CPC when the emu launch.
 
@@ -84,10 +87,6 @@ All you have to do is to add a comment like this in the m3u file :
 #COMMAND:<YOUR_COMMAND_HERE>
 ```
 
-If the autolaunch option of the core does a pretty good job to guess what command must be executed to launch a game on the CPC, there is some problems (cpm disk and strange catalogs for the most).
-
-Here, this little option come to the rescue.
-
 Even for one disk game, you can create a m3u file like this one :
 
 Jack the Nipper II... In Coconut Capers.m3u
@@ -95,8 +94,6 @@ Jack the Nipper II... In Coconut Capers.m3u
 #COMMAND:|CPM
 Jack the Nipper II... In Coconut Capers (E).dsk
 ```
-
-And it's done.
 
 ## Core options
 


### PR DESCRIPTION
If autorun was disabled and the m3u file had a command specified, the first character of the command was repeated without end.

Probably, tape had the same problem.