### PR TITLE
c89 compatible for loops (move declaration to start of functions)

### DIFF
--- a/libretro/disk_control.c
+++ b/libretro/disk_control.c
@@ -147,6 +147,8 @@ char* m3u_search_file(char* basedir, char* dskName)
 
 void dc_reset(dc_storage* dc)
 {
+	unsigned i;
+
 	// Verify
 	if(dc == NULL)
 		return;
@@ -159,7 +161,7 @@ void dc_reset(dc_storage* dc)
 	}
 
 	// Clean the struct
-	for(unsigned i=0; i < dc->count; i++)
+	for(i=0; i < dc->count; i++)
 	{
 		free(dc->files[i]);
 		dc->files[i] = NULL;
@@ -171,6 +173,8 @@ void dc_reset(dc_storage* dc)
 
 dc_storage* dc_create(void)
 {
+	int i;
+
 	// Initialize the struct
 	dc_storage* dc = NULL;
 	
@@ -180,7 +184,7 @@ dc_storage* dc_create(void)
 		dc->index = -1;
 		dc->eject_state = true;
 		dc->command = NULL;
-		for(int i = 0; i < DC_MAX_SIZE; i++)
+		for(i = 0; i < DC_MAX_SIZE; i++)
 		{
 			dc->files[i] = NULL;
 		}

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -897,6 +897,7 @@ void retro_run(void)
 {
    static int mfirst=1;
    bool updated = false;
+   unsigned i;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       update_variables();
@@ -918,7 +919,7 @@ void retro_run(void)
 
 				// Some debugging
 				log_cb(RETRO_LOG_INFO, "m3u file parsed, %d file(s) found\n", dc->count);
-				for(unsigned i = 0; i < dc->count; i++)
+				for(i = 0; i < dc->count; i++)
 				{
 					log_cb(RETRO_LOG_INFO, "file %d: %s\n", i+1, dc->files[i]);
 				}


### PR DESCRIPTION
Note that the indentation and line endings between the two files differs (and libretro/libretro-core.c contains a mess of tabs and spaces due to previous commits which introduced wrong indentation).

I have left the indentation and line endings alone, but it should be fixed IMHO.