### PR TITLE
Simple joystick config

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1010,7 +1010,7 @@ void retro_set_controller_port_device( unsigned port, unsigned device )
    {
       amstrad_devices[ port ] = device;
 
-      printf(" (%d)=%d \n",port,device);
+      /*printf(" (%d)=%d \n",port,device);*/
    }
 }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -416,11 +416,11 @@ void retro_set_environment(retro_environment_t cb)
    struct retro_variable variables[] = {
       {
          "cap32_retrojoy0",
-         "User 1 Amstrad Joystick Config; joystick|qaop|incentive",
+         "User 1 Amstrad Joystick Config; joystick|qaop|incentive|simple",
       },
       {
          "cap32_retrojoy1",
-         "User 2 Amstrad Joystick Config; joystick|qaop|incentive",
+         "User 2 Amstrad Joystick Config; joystick|qaop|incentive|simple",
       },
 	   {
 		   "cap32_autorun",
@@ -475,7 +475,7 @@ void retro_set_environment(retro_environment_t cb)
  *
  * Query retro_environment callback to get joy values
  *
- * Returns: current user joy config (0/1/2),selected in GUI
+ * Returns: current user joy config (0/1/2/3),selected in GUI
  *          otherwise default config 0 (joystick)
  **/
 static int controller_port_variable(unsigned port, struct retro_variable *var)
@@ -497,8 +497,10 @@ static int controller_port_variable(unsigned port, struct retro_variable *var)
    {
       if(strcmp(var->value, "qaop") == 0)
          return 1;
-      if(strcmp(var->value, "incentive") == 0)
+      else if(strcmp(var->value, "incentive") == 0)
          return 2;
+      else if(strcmp(var->value, "simple") == 0)
+         return 3;
    }
 
    return 0;
@@ -953,7 +955,7 @@ void retro_init(void)
    retro_computer_cfg.ram = -1;
    retro_computer_cfg.lang = -1;
    retro_computer_cfg.padcfg[ID_PLAYER1] = 0;
-   retro_computer_cfg.padcfg[ID_PLAYER2] = 1;
+   retro_computer_cfg.padcfg[ID_PLAYER2] = 0;
 
    update_variables();
 

--- a/libretro/retro_events.c
+++ b/libretro/retro_events.c
@@ -48,13 +48,14 @@ const uint8_t bit_values[8] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80 };
 // --- events code
 #define MAX_KEYSYMS 324
 #define MAX_BUTTONS 14
-#define MAX_PADCFG 3
+#define MAX_PADCFG 4
 
 static uint8_t keyboard_translation[MAX_KEYSYMS];
 unsigned int last_input[PORTS_NUMBER] = {0,0};
 uint32_t padnum = 0;
 
 const uint8_t btnPAD[MAX_PADCFG][MAX_BUTTONS] = {
+   /*profile: Joystick*/
    {
    CPC_KEY_JOY_FIRE2,   // B
    CPC_KEY_SPACE,       // Y
@@ -72,6 +73,7 @@ const uint8_t btnPAD[MAX_PADCFG][MAX_BUTTONS] = {
    CPC_KEY_CONTROL,     // L2
    CPC_KEY_COPY,        // R2
    },
+   /*profile: QAOP*/
    {
    CPC_KEY_F1,          // B
    CPC_KEY_F2,          // Y
@@ -89,6 +91,7 @@ const uint8_t btnPAD[MAX_PADCFG][MAX_BUTTONS] = {
    CPC_KEY_CONTROL,     // L2
    CPC_KEY_COPY,        // R2
    },
+   /*profile: Incentive*/
    {
    CPC_KEY_SPACE,       // B
    CPC_KEY_W,           // Y
@@ -105,6 +108,24 @@ const uint8_t btnPAD[MAX_PADCFG][MAX_BUTTONS] = {
    CPC_KEY_L,           // R
    CPC_KEY_R,           // L2
    CPC_KEY_U,           // R2
+   },
+   /*profile: Simple*/
+   {
+   CPC_KEY_JOY_FIRE1,   // B
+   CPC_KEY_NULL,        // Y
+   CPC_KEY_NULL,        // SELECT
+   CPC_KEY_NULL,        // START
+   CPC_KEY_JOY_UP,      // DUP
+   CPC_KEY_JOY_DOWN,    // DDOWN
+   CPC_KEY_JOY_LEFT,    // DLEFT
+   CPC_KEY_JOY_RIGHT,   // DRIGHT
+   CPC_KEY_JOY_FIRE2,   // A
+   CPC_KEY_NULL,        // X
+   //---------------------
+   CPC_KEY_NULL,        // L
+   CPC_KEY_NULL,        // R
+   CPC_KEY_NULL,        // L2
+   CPC_KEY_NULL,        // R2
    }
 };
 
@@ -207,9 +228,11 @@ static void ev_special_combos()
  **/
 static void ev_process_joy(int playerID){
 
-   if( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT)) {
-      ev_special_combos();
-      return;
+   if( retro_computer_cfg.padcfg[playerID]!=3/*simple*/) {
+      if( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT)) {
+         ev_special_combos();
+         return;
+      }
    }
 
    uint8_t * pad = (uint8_t*) &btnPAD[retro_computer_cfg.padcfg[playerID]];

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,18 @@ R | L
 L2 | R
 R2 | U
 
-If you press [SELECT] you could make a combo with other buttons:
+JOY CONFIG SIMPLE (JOYSTICK)
+------------
+JOY BUTTON | CPC
+------------ | -------------
+DPAD-UP | JOY-UP
+DPAD-DOWN | JOY-DOWN
+DPAD-LEFT | JOY-LEFT
+DPAD-RIGHT | JOY-RIGHT
+B | FIRE1
+A | FIRE2
+
+If you press [SELECT] you could make a combo with other buttons (unless using SIMPLE config):
 
 JOY BUTTON | ON CPC WRITES
 ------------ | -------------
@@ -161,7 +172,7 @@ Jack the Nipper II... In Coconut Capers (E).dsk
 
 If enabled a RUN the first bas/bin found in DSK
 
-### User 1/2 Amstrad Joystick Config - joystick, qaop or incentive
+### User 1/2 Amstrad Joystick Config - joystick, qaop, incentive or simple
 
 Select Joy/Overlay configuration
 


### PR DESCRIPTION
Adds a new joystick config called "simple" which implements a basic no-frills joystick with no secret keyboard shortcuts or combo options present.

D-PAD controls movement.
Fire 1 is B (bottom face button on SNES/RetroPad controller)
Fire 2 is A (right face button)

