### PR TITLE
Revert "Changing Android optimizations to -Ofast (...)"

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,8 +1,2 @@
 APP_ABI := all
-# Without the -Ofast here, the core crashes on armv7a devices when opening the on-screen keyboard with L.
-# The crash is due to some unaligned memory access (BUS_ADRALN) and doesn't happen on other platforms.
-# Building the core with the buildbot running NDK v20 on linux with default flags caused the crash.
-# Building the core with NDK v20 on Darwin must use different default flags or do something else different
-# because the crash didn't happen with those builds, and the resulting .so was also ~700 kb larger in size.
-# This should be investigated more in the future.
-APP_CFLAGS += -Wno-error=format-security -Ofast
+APP_CFLAGS += -O0


### PR DESCRIPTION
This reverts commit 6c50e6c19062414a52e71d94d745d4dc5ac918b4.

It was worth a try because it worked in Vice, but here with cap32, -Ofast causes crashes on loading game. So revert back to -O0 since it is the only setting that works without crashes
it seems.

See https://github.com/libretro/libretro-cap32/issues/45#issuecomment-518421279