### PR TITLE
fix off-by-one offset on SNA files

### DIFF
--- a/cap32/cap32.h
+++ b/cap32/cap32.h
@@ -112,7 +112,7 @@
 
 typedef struct {
    char id[8+1];
-   char unused1[8];
+   char unused1[7];
    unsigned char version;
    unsigned char AF[2];
    unsigned char BC[2];


### PR DESCRIPTION
Fix regarding https://github.com/libretro/libretro-cap32/issues/105